### PR TITLE
fix: multiple bugs across shell, lua and python modules

### DIFF
--- a/ruantiblock-mod-lua/files/usr/libexec/ruantiblock/ruab_parser.lua
+++ b/ruantiblock-mod-lua/files/usr/libexec/ruantiblock/ruab_parser.lua
@@ -153,7 +153,7 @@ end
 function Config:load_environ_config()
     local cfg_table = {}
     for var in pairs(self.environ_table) do
-        val = os.getenv(var)
+        local val = os.getenv(var)
         if val then
             cfg_table[var] = val
         end
@@ -234,7 +234,7 @@ end
 -- Loading filters
 
 function Config:load_filter_files()
-    function load_file(file, t, is_array, func)
+    local function load_file(file, t, is_array, func)
         local file_handler = io.open(file, "r")
         if file_handler then
             for line in file_handler:lines() do
@@ -604,11 +604,11 @@ function Summarize:_group_ip_ranges(ip_list, raw_list)
         for i = start, stop do
             if raw_list[i] then
                 raw_list[i] = nil
-                return
-            end
-            local item = it.int_to_ip(i)
-            if raw_list[item] then
-                raw_list[it.int_to_ip(i)] = nil
+            else
+                local item = it.int_to_ip(i)
+                if raw_list[item] then
+                    raw_list[item] = nil
+                end
             end
         end
     end

--- a/ruantiblock-mod-py/files/usr/libexec/ruantiblock/ruab_parser.py
+++ b/ruantiblock-mod-py/files/usr/libexec/ruantiblock/ruab_parser.py
@@ -477,7 +477,7 @@ class Summarize:
     def _group_ip_ranges(cls, ip_list, raw_list=None):
         def remove_items(start, end):
             for ip in range(int(start), int(end) + 1):
-                raw_list.remove(str(IPv4Address(ip)))
+                raw_list.pop(str(IPv4Address(ip)), None)
 
         start = end = None
         hosts = 1

--- a/ruantiblock/files/usr/bin/ruantiblock
+++ b/ruantiblock/files/usr/bin/ruantiblock
@@ -36,7 +36,7 @@ export PROXY_MODE=1
 export PROXY_LOCAL_CLIENTS=0
 ### Удаление записей сетов перед началом обновления (для освобождения оперативной памяти перед обновлением сетов) (0 - выкл, 1 - вкл)
 export NFTSET_CLEAR_SETS=0
-### Искоючить из обхода блокировок пакеты, у которых адрес назначения совпадает с любым IP адресом любого из интерфейсов роутера (0 - выкл, 1 - вкл)
+### Исключить из обхода блокировок пакеты, у которых адрес назначения совпадает с любым IP адресом любого из интерфейсов роутера (0 - выкл, 1 - вкл)
 export IGNORE_LOCAL_IP=1
 ### Режим фильтра хостов которым разрешено обходить блокировки (0 - выкл., 1 - только адреса из списка, 2 - любые адреса кроме присутствующих в списке)
 export ALLOWED_HOSTS_MODE=0
@@ -234,11 +234,12 @@ if [ $? -ne 0 ]; then
     echo " Error! Nftables doesn't exists" >&2
     exit 1
 fi
-export LOGGER_CMD="$(which logger)"
-if [ $ENABLE_LOGGING = "1" -a $? -ne 0 ]; then
+LOGGER_CMD="$(which logger)"
+if [ "$ENABLE_LOGGING" = "1" -a $? -ne 0 ]; then
     echo " Logger doesn't exists" >&2
     ENABLE_LOGGING=0
 fi
+export LOGGER_CMD
 export LOGGER_PARAMS="-t ${APP_NAME}"
 export WGET_CMD="$(which wget)"
 if [ $? -ne 0 ]; then
@@ -251,11 +252,12 @@ if [ $? -ne 0 ]; then
     echo " Error! Nslookup doesn't exists" >&2
     exit 1
 fi
-export IP_CMD="ip"
+IP_CMD="$(which ip)"
 if [ $? -ne 0 ]; then
     echo " Error! Iproute2 doesn't exists" >&2
     exit 1
 fi
+export IP_CMD
 USER_ENTRIES_PARSER="${MODULES_DIR}/ruab_parser_user_entries"
 ROUTE_CHECK_EXEC="${MODULES_DIR}/ruab_route_check"
 export IP_DATA_FILE="${DATA_DIR}/${NAME}.ip"
@@ -791,7 +793,6 @@ AddUserEntries() {
 
     if [ "$ENABLE_TMP_DOWNLOADS" = "1" ]; then
         _ip_data_file_user_instances="$IP_DATA_FILE_USER_INSTANCES_TMP"
-        _dnsmasq_data_file="$DNSMASQ_DATA_FILE_TMP"
         _dnsmasq_data_file_user_instances="$DNSMASQ_DATA_FILE_USER_INSTANCES_TMP"
         _user_entries_status_file="$USER_ENTRIES_STATUS_FILE_TMP"
         rm -f "$_ip_data_file_user_instances" "$_dnsmasq_data_file_user_instances" "$_user_entries_status_file"
@@ -1221,7 +1222,7 @@ StatusOutput() {
 return_code=1
 case "$1" in
     start|force-start)
-        [ "$1" == "force-start" ] && rm -f "$START_PID_FILE"
+        [ "$1" = "force-start" ] && rm -f "$START_PID_FILE"
         Start "$1"
         return_code=$?
         StatusOutput
@@ -1233,7 +1234,7 @@ case "$1" in
         StatusOutput
     ;;
     restart|delayed-restart)
-        if [ "$1" == "delayed-restart" -a -n "$2" ]; then
+        if [ "$1" = "delayed-restart" -a -n "$2" ]; then
             {
                 echo "$$" > "$START_PID_FILE"
                 sleep $2 &> /dev/null
@@ -1276,7 +1277,7 @@ case "$1" in
             :
         else
             echo " ${NAME} ${_arg} - Error! ${NAME} does not running or another error has occurred" >&2
-            return 1
+            exit 1
         fi
         UpdateLocalIpSets
         if CheckDnsmasqConfDir; then


### PR DESCRIPTION
Shell (ruantiblock):
- fix broken 'ip' command check — was 'export IP_CMD=ip' followed by checking $? (always 0 from export); now uses 'which ip' like other utility checks
- fix LOGGER_CMD check — export swallowed which exit code; split assignment and export
- fix 'return 1' outside function in main case block — changed to 'exit 1'
- fix '==' to '=' in test expressions for POSIX sh compliance (script uses #!/bin/sh)
- fix typo 'Искоючить' -> 'Исключить' in comment
- remove unused variable _dnsmasq_data_file in AddUserEntries()

Lua (ruab_parser.lua):
- fix global variable leak: 'val' in Config:load_environ_config() was not declared local, polluting global scope
- fix global function leak: 'load_file' inside Config:load_filter_files() was not declared local
- fix premature return in Summarize.remove_items() — only first matching item was deleted from range, rest were skipped

Python (ruab_parser.py):
- fix AttributeError crash in Summarize._group_ip_ranges() — raw_list is a dict but .remove() was called (dict method); changed to .pop() with default None